### PR TITLE
Automate static example portfolio deployment

### DIFF
--- a/.github/workflows/static-portfolio.yml
+++ b/.github/workflows/static-portfolio.yml
@@ -2,7 +2,7 @@ name: Build static example portfolio
 
 on:
   push:
-    branches: [ main, work ]
+    branches: [ master ]
   pull_request:
     paths:
       - 'examples/static/**'
@@ -32,6 +32,7 @@ jobs:
           fetch-depth: 0
 
       - name: Configure GitHub Pages
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: actions/configure-pages@v4
 
       - name: Install build dependencies
@@ -44,11 +45,13 @@ jobs:
         run: python3 scripts/generate_static_portfolio.py
 
       - name: Upload GitHub Pages artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: actions/upload-pages-artifact@v3
         with:
           path: portfolio
 
   deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     needs: build
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/static-portfolio.yml
+++ b/.github/workflows/static-portfolio.yml
@@ -1,0 +1,60 @@
+name: Build static example portfolio
+
+on:
+  push:
+    branches: [ main, work ]
+  pull_request:
+    paths:
+      - 'examples/static/**'
+      - 'include/**'
+      - 'src/**'
+      - 'static/**'
+      - 'scripts/**'
+      - '.github/workflows/static-portfolio.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v4
+
+      - name: Install build dependencies
+        run: sudo apt-get update && sudo apt-get install -y build-essential
+
+      - name: Build static examples
+        run: make examples-static
+
+      - name: Generate portfolio site
+        run: python3 scripts/generate_static_portfolio.py
+
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: portfolio
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,6 @@ prompt
 edulcni/build
 edulcni-old
 build
+out/
 *_output
-examples/static
-examples/interactive
+portfolio/

--- a/README.md
+++ b/README.md
@@ -464,6 +464,24 @@ edulcni/
 └── lib/              # Shared library output (when built)
 ```
 
+## Publishing the Static Portfolio
+
+The repository ships with an automated GitHub Pages pipeline (see [`static-portfolio.yml`](.github/workflows/static-portfolio.yml)) that
+builds every static example, runs each binary to export the visualizations, and publishes the resulting gallery under a single portfolio
+site. Pushes to the `main` or `work` branches automatically refresh the published pages, and the workflow can also be triggered on-demand
+from the Actions tab.
+
+To reproduce the GitHub Pages artifact locally, run:
+
+```bash
+make examples-static
+python3 scripts/generate_static_portfolio.py
+```
+
+The command above creates a `portfolio/` directory containing per-example exports, lightweight redirect helpers, a searchable `portfolio.json`
+manifest, and an `index.html` landing page that links to every visualization. Open `portfolio/index.html` in your browser to explore the gallery
+without waiting for the action to finish.
+
 ## Contributing
 
 1. Fork the repository

--- a/examples/static/data_structure_showcase.cpp
+++ b/examples/static/data_structure_showcase.cpp
@@ -1,0 +1,151 @@
+#include <edulcni.hpp>
+#include <numeric>
+#include <cmath>
+#include <vector>
+#include <algorithm>
+
+int main() {
+    edulcni::initialize("out/data_structure_showcase");
+    edulcni::reset_layout(edulcni::LayoutStrategy::VerticalStack);
+
+    std::vector<int> base = {5, 1, 7, 3, 6, 4, 2, 9};
+
+    // ------------------------------------------------------------------
+    // Segment tree view
+    // ------------------------------------------------------------------
+    edulcni::SegmentTreeView segment_tree("segment_tree", base.size());
+
+    const size_t offset = segment_tree.leaf_offset();
+    std::vector<int> tree_values(segment_tree.node_count(), 0);
+    for (size_t i = 0; i < base.size(); ++i) {
+        tree_values[offset + i] = base[i];
+    }
+    for (int idx = static_cast<int>(offset) - 1; idx >= 0; --idx) {
+        tree_values[idx] = tree_values[2 * idx + 1] + tree_values[2 * idx + 2];
+    }
+    for (size_t i = 0; i < tree_values.size(); ++i) {
+        segment_tree.set_value(i, std::to_string(tree_values[i]));
+    }
+
+    edulcni::step();
+
+    segment_tree.highlight_range(2, 5);
+    edulcni::step();
+    segment_tree.clear_highlights();
+
+    // ------------------------------------------------------------------
+    // Sparse table view (range minimum queries)
+    // ------------------------------------------------------------------
+    size_t n = base.size();
+    size_t levels = static_cast<size_t>(std::floor(std::log2(n))) + 1;
+    std::vector<std::vector<int>> sparse_values(levels, std::vector<int>(n, 0));
+    std::vector<std::vector<bool>> valid(levels, std::vector<bool>(n, false));
+    std::vector<std::vector<std::pair<int, int>>> sparse_ranges(levels, std::vector<std::pair<int, int>>(n, {0, -1}));
+
+    for (size_t i = 0; i < n; ++i) {
+        sparse_values[0][i] = base[i];
+        valid[0][i] = true;
+        sparse_ranges[0][i] = {static_cast<int>(i), static_cast<int>(i)};
+    }
+
+    for (size_t k = 1; k < levels; ++k) {
+        size_t len = 1u << k;
+        for (size_t i = 0; i + len <= n; ++i) {
+            sparse_values[k][i] = std::min(
+                sparse_values[k - 1][i],
+                sparse_values[k - 1][i + (len >> 1)]
+            );
+            valid[k][i] = true;
+            sparse_ranges[k][i] = {
+                static_cast<int>(i),
+                static_cast<int>(i + len - 1)
+            };
+        }
+    }
+
+    std::vector<std::vector<std::string>> sparse_display(levels, std::vector<std::string>(n, ""));
+    for (size_t k = 0; k < levels; ++k) {
+        for (size_t i = 0; i < n; ++i) {
+            if (valid[k][i]) {
+                sparse_display[k][i] = std::to_string(sparse_values[k][i]);
+            }
+        }
+    }
+
+    edulcni::sparse_table_widget("sparse_table", sparse_display, sparse_ranges);
+    edulcni::step();
+
+    edulcni::matrix_highlight("sparse_table", 2, 1);
+    edulcni::step();
+    edulcni::matrix_clear_highlights("sparse_table");
+
+    // ------------------------------------------------------------------
+    // Treap view
+    // ------------------------------------------------------------------
+    edulcni::TreapView treap("treap_structure");
+    std::vector<edulcni::TreapView::Node> treap_nodes = {
+        {8, "8", "30", 3, 10, edulcni::render::Color(129, 199, 132)},
+        {3, "3", "45", 1, 6, edulcni::render::Color(144, 202, 249)},
+        {10, "10", "20", -1, 14, edulcni::render::Color(255, 224, 130)},
+        {1, "1", "80", -1, -1, edulcni::render::Color(244, 143, 177)},
+        {6, "6", "60", -1, 7, edulcni::render::Color(206, 147, 216)},
+        {14, "14", "10", 13, -1, edulcni::render::Color(255, 205, 210)},
+        {7, "7", "50", -1, -1, edulcni::render::Color(197, 202, 233)},
+        {13, "13", "15", -1, -1, edulcni::render::Color(255, 171, 145)}
+    };
+    treap.set_tree(treap_nodes, 8);
+    treap.highlight(6);
+    treap.highlight(7);
+    edulcni::step();
+    treap.clear_highlights();
+
+    // ------------------------------------------------------------------
+    // Sqrt decomposition view
+    // ------------------------------------------------------------------
+    edulcni::SqrtDecompositionView sqrt_view("sqrt_decomposition");
+    sqrt_view.set_array(base);
+
+    size_t block_size = static_cast<size_t>(std::ceil(std::sqrt(static_cast<double>(base.size()))));
+    std::vector<int> block_values;
+    for (size_t i = 0; i < base.size(); i += block_size) {
+        int block_sum = 0;
+        for (size_t j = i; j < std::min(base.size(), i + block_size); ++j) {
+            block_sum += base[j];
+        }
+        block_values.push_back(block_sum);
+    }
+    sqrt_view.set_blocks(block_values);
+
+    sqrt_view.highlight_block(1);
+    sqrt_view.highlight_element(3);
+    edulcni::step();
+    sqrt_view.clear_highlights();
+
+    // ------------------------------------------------------------------
+    // Line container (Convex Hull Trick) view
+    // ------------------------------------------------------------------
+    edulcni::LineContainerView line_view("line_container");
+    line_view.set_domain(0.0, 10.0);
+    line_view.set_lines({
+        {2.0, 3.0, "2x + 3", edulcni::render::Color(52, 152, 219), false},
+        {1.0, 8.0, "x + 8", edulcni::render::Color(46, 204, 113), false},
+        {-0.5, 20.0, "-0.5x + 20", edulcni::render::Color(231, 76, 60), false}
+    });
+    line_view.set_queries({
+        {2.0, 0, edulcni::render::Color(155, 89, 182)},
+        {5.0, 2, edulcni::render::Color(241, 196, 15)}
+    });
+
+    line_view.highlight_line(0, true);
+    edulcni::step();
+
+    line_view.highlight_line(0, false);
+    line_view.highlight_line(2, true);
+    line_view.set_queries({
+        {7.0, 2, edulcni::render::Color(39, 174, 96)}
+    });
+    edulcni::step();
+
+    return 0;
+}
+

--- a/include/edulcni/core/export.hpp
+++ b/include/edulcni/core/export.hpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <fstream>
 #include <filesystem>
+#include <cmath>
 #include "edulcni/core/frame.hpp"
 
 namespace edulcni {
@@ -27,14 +28,34 @@ public:
 private:
     void export_frame_data(const std::string& output_dir, const std::vector<Frame>& frames) {
         std::ofstream js_file(output_dir + "/data.js");
-        js_file << "window.frameData = [\n";
-        
+
+        render::Bounds global_bounds = render::Bounds::empty();
+        for (const auto& frame : frames) {
+            global_bounds.expand(frame.bounds());
+        }
+
+        const double margin = 40.0;
+        double width = std::max(800.0, global_bounds.width() + margin * 2.0);
+        double height = std::max(600.0, global_bounds.height() + margin * 2.0);
+        double offset_x = global_bounds.is_empty() ? 0.0 : (global_bounds.min_x - margin);
+        double offset_y = global_bounds.is_empty() ? 0.0 : (global_bounds.min_y - margin);
+
+        js_file << "window.frameData = {\n";
+        js_file << "    canvas: {\n";
+        js_file << "        width: " << static_cast<int>(std::ceil(width)) << ",\n";
+        js_file << "        height: " << static_cast<int>(std::ceil(height)) << ",\n";
+        js_file << "        offsetX: " << offset_x << ",\n";
+        js_file << "        offsetY: " << offset_y << "\n";
+        js_file << "    },\n";
+        js_file << "    frames: [\n";
+
         for (size_t i = 0; i < frames.size(); ++i) {
             if (i > 0) js_file << ",\n";
-            js_file << "    " << frames[i].to_canvas_js();
+            js_file << "        " << frames[i].to_canvas_js();
         }
-        
-        js_file << "\n];\n";
+
+        js_file << "\n    ]\n";
+        js_file << "};\n";
         js_file.close();
     }
     

--- a/include/edulcni/core/frame.hpp
+++ b/include/edulcni/core/frame.hpp
@@ -16,15 +16,19 @@ namespace internal {
 class Frame {
 private:
     std::map<std::string, std::unique_ptr<render::Element>> widget_renders_;
-    
+    render::Bounds bounds_ = render::Bounds::empty();
+
 public:
     Frame() = default;
-    
+
     void add_widget_state(const std::string& id, std::unique_ptr<render::Element> render) {
         // widget_states_[id] = state;
+        if (render) {
+            bounds_.expand(render->bounds());
+        }
         widget_renders_[id] = std::move(render);
     }
-    
+
     std::string to_canvas_js() const {
         std::ostringstream js;
         js << "function(ctx, canvas) {\n";
@@ -37,6 +41,10 @@ public:
         
         js << "}\n";
         return js.str();
+    }
+
+    const render::Bounds& bounds() const {
+        return bounds_;
     }
 };
 

--- a/include/edulcni/core/render.hpp
+++ b/include/edulcni/core/render.hpp
@@ -6,9 +6,77 @@
 #include <string>
 #include <vector>
 #include <sstream>
+#include <algorithm>
+#include <limits>
 
 namespace edulcni {
 namespace render {
+
+struct Bounds {
+    double min_x;
+    double min_y;
+    double max_x;
+    double max_y;
+
+    static Bounds empty() {
+        return Bounds{std::numeric_limits<double>::max(),
+                      std::numeric_limits<double>::max(),
+                      std::numeric_limits<double>::lowest(),
+                      std::numeric_limits<double>::lowest()};
+    }
+
+    static Bounds from_point(double x, double y) {
+        return Bounds{x, y, x, y};
+    }
+
+    bool is_empty() const {
+        return min_x > max_x || min_y > max_y;
+    }
+
+    void expand(double x, double y) {
+        if (is_empty()) {
+            min_x = max_x = x;
+            min_y = max_y = y;
+            return;
+        }
+        min_x = std::min(min_x, x);
+        min_y = std::min(min_y, y);
+        max_x = std::max(max_x, x);
+        max_y = std::max(max_y, y);
+    }
+
+    void expand(const Bounds& other) {
+        if (other.is_empty()) {
+            return;
+        }
+        if (is_empty()) {
+            *this = other;
+            return;
+        }
+        min_x = std::min(min_x, other.min_x);
+        min_y = std::min(min_y, other.min_y);
+        max_x = std::max(max_x, other.max_x);
+        max_y = std::max(max_y, other.max_y);
+    }
+
+    void translate(double dx, double dy) {
+        if (is_empty()) {
+            return;
+        }
+        min_x += dx;
+        max_x += dx;
+        min_y += dy;
+        max_y += dy;
+    }
+
+    double width() const {
+        return is_empty() ? 0.0 : (max_x - min_x);
+    }
+
+    double height() const {
+        return is_empty() ? 0.0 : (max_y - min_y);
+    }
+};
 
 // Color type
 struct Color {
@@ -43,12 +111,14 @@ class Element {
 public:
     virtual ~Element() = default;
     virtual std::string to_canvas_js() const = 0;
-    
+
     // Move the element to the right by the specified amount
     virtual void to_right(double offset) = 0;
-    
+
     // Move the element down by the specified amount
     virtual void to_bottom(double offset) = 0;
+
+    virtual Bounds bounds() const = 0;
 };
 
 // Container for multiple elements
@@ -86,6 +156,19 @@ public:
     // Move the group and all its children down
     void to_bottom(double offset) override {
         y_ += offset;
+    }
+
+    Bounds bounds() const override {
+        Bounds total = Bounds::empty();
+        for (const auto& child : children_) {
+            Bounds child_bounds = child->bounds();
+            child_bounds.translate(x_, y_);
+            total.expand(child_bounds);
+        }
+        if (children_.empty()) {
+            total = Bounds::from_point(x_, y_);
+        }
+        return total;
     }
 };
 
@@ -126,6 +209,12 @@ public:
     void to_bottom(double offset) override {
         y_ += offset;
     }
+
+    Bounds bounds() const override {
+        Bounds b = Bounds::from_point(x_, y_);
+        b.expand(x_ + width_, y_ + height_);
+        return b;
+    }
 };
 
 // Text element
@@ -161,6 +250,22 @@ public:
     // Move the text down
     void to_bottom(double offset) override {
         y_ += offset;
+    }
+
+    Bounds bounds() const override {
+        double approx_width = std::max(10.0, static_cast<double>(text_.size()) * 8.0);
+        double approx_height = 18.0;
+        double left = x_;
+
+        if (align_ == "center") {
+            left -= approx_width / 2.0;
+        } else if (align_ == "right") {
+            left -= approx_width;
+        }
+
+        Bounds b = Bounds::from_point(left, y_ - approx_height / 2.0);
+        b.expand(left + approx_width, y_ + approx_height / 2.0);
+        return b;
     }
 };
 
@@ -198,6 +303,12 @@ public:
     void to_bottom(double offset) override {
         y1_ += offset;
         y2_ += offset;
+    }
+
+    Bounds bounds() const override {
+        Bounds b = Bounds::from_point(x1_, y1_);
+        b.expand(x2_, y2_);
+        return b;
     }
 };
 
@@ -240,6 +351,12 @@ public:
     void to_bottom(double offset) override {
         y_ += offset;
     }
+
+    Bounds bounds() const override {
+        Bounds b = Bounds::from_point(x_ - radius_, y_ - radius_);
+        b.expand(x_ + radius_, y_ + radius_);
+        return b;
+    }
 };
 
 // Transform element for zoom-pan and other transformations
@@ -265,6 +382,10 @@ public:
     
     void to_bottom(double offset) override {
         f_ += offset;
+    }
+
+    Bounds bounds() const override {
+        return Bounds::empty();
     }
 };
 

--- a/include/edulcni/widgets.hpp
+++ b/include/edulcni/widgets.hpp
@@ -9,3 +9,4 @@
 #include "edulcni/widgets/label.hpp"
 #include "edulcni/widgets/geometry.hpp"
 #include "edulcni/widgets/recursion.hpp"
+#include "edulcni/widgets/data_structures.hpp"

--- a/include/edulcni/widgets/data_structures.hpp
+++ b/include/edulcni/widgets/data_structures.hpp
@@ -1,0 +1,182 @@
+/**
+ * Data structure helper widgets for edulcni
+ */
+#pragma once
+
+#include <string>
+#include <vector>
+#include <utility>
+#include <unordered_map>
+#include <cstddef>
+
+#include "edulcni/core/state.hpp"
+#include "edulcni/core/render.hpp"
+#include "edulcni/widgets/graph.hpp"
+#include "edulcni/widgets/array.hpp"
+#include "edulcni/widgets/matrix.hpp"
+#include "edulcni/utils/to_string.hpp"
+
+namespace edulcni {
+
+using LayoutStrategy = internal::LayoutStrategy;
+
+// -----------------------------------------------------------------------------
+// Sparse table helper
+// -----------------------------------------------------------------------------
+
+template <typename T>
+void sparse_table_widget(const std::string& id,
+                         const std::vector<std::vector<T>>& table,
+                         const std::vector<std::vector<std::pair<int, int>>>& intervals = {}) {
+    std::vector<std::vector<std::string>> display(table.size());
+    for (size_t i = 0; i < table.size(); ++i) {
+        display[i].resize(table[i].size());
+        for (size_t j = 0; j < table[i].size(); ++j) {
+            std::string value_str = internal::to_string_any(table[i][j]);
+            if (i < intervals.size() && j < intervals[i].size()) {
+                const auto& range = intervals[i][j];
+                if (range.first <= range.second) {
+                    value_str = "[" + std::to_string(range.first) + "," + std::to_string(range.second) + "] " + value_str;
+                }
+            }
+            display[i][j] = std::move(value_str);
+        }
+    }
+
+    matrix_widget(id, display);
+}
+
+// -----------------------------------------------------------------------------
+// Segment tree visualizer
+// -----------------------------------------------------------------------------
+
+class SegmentTreeView {
+public:
+    SegmentTreeView(const std::string& id, size_t leaf_count);
+
+    void set_value(size_t node_index, const std::string& value);
+    void set_leaf_value(size_t leaf_index, const std::string& value);
+    void clear_values();
+
+    void highlight_node(size_t node_index, bool highlight = true);
+    void highlight_range(size_t left, size_t right, bool highlight = true);
+    void clear_highlights();
+
+    size_t node_count() const { return values_.size(); }
+    size_t leaf_offset() const { return base_size_ > 0 ? base_size_ - 1 : 0; }
+
+private:
+    std::string id_;
+    internal::GraphWidgetBase* widget_ = nullptr;
+    std::vector<std::string> values_;
+    std::vector<std::pair<size_t, size_t>> ranges_;
+    std::vector<bool> active_;
+    size_t leaf_count_ = 0;
+    size_t base_size_ = 1;
+
+    void build_structure();
+    void compute_ranges(size_t index, size_t left, size_t right);
+    void update_labels();
+};
+
+// -----------------------------------------------------------------------------
+// Treap visualizer
+// -----------------------------------------------------------------------------
+
+class TreapView {
+public:
+    struct Node {
+        int id;
+        std::string key;
+        std::string priority;
+        int left = -1;
+        int right = -1;
+        render::Color color = render::Color(200, 200, 255);
+        bool highlighted = false;
+    };
+
+    TreapView(const std::string& id);
+
+    void set_tree(const std::vector<Node>& nodes, int root_id);
+    void highlight(int node_id, bool highlight = true);
+    void clear_highlights();
+
+private:
+    std::string id_;
+    internal::GraphWidgetBase* widget_ = nullptr;
+    std::unordered_map<int, size_t> id_to_index_;
+};
+
+// -----------------------------------------------------------------------------
+// Sqrt decomposition helper
+// -----------------------------------------------------------------------------
+
+class SqrtDecompositionView {
+public:
+    explicit SqrtDecompositionView(const std::string& id);
+
+    template <typename T>
+    void set_array(const std::vector<T>& values) {
+        vector_widget(array_id_, values);
+    }
+
+    template <typename T>
+    void set_blocks(const std::vector<T>& block_values) {
+        vector_widget(blocks_id_, block_values);
+    }
+
+    void highlight_element(size_t index);
+    void highlight_block(size_t index);
+    void clear_highlights();
+
+private:
+    std::string array_id_;
+    std::string blocks_id_;
+};
+
+// -----------------------------------------------------------------------------
+// Line container helper
+// -----------------------------------------------------------------------------
+
+namespace internal {
+    class LineContainerWidget;
+}
+
+class LineContainerView {
+public:
+    struct LineDefinition {
+        double slope;
+        double intercept;
+        std::string label;
+        render::Color color = render::Color(52, 152, 219);
+        bool highlighted = false;
+    };
+
+    struct QueryPoint {
+        double x;
+        size_t line_index;
+        render::Color color = render::Color::Red();
+    };
+
+    explicit LineContainerView(const std::string& id);
+
+    void set_domain(double min_x, double max_x);
+    void set_lines(const std::vector<LineDefinition>& lines);
+    void set_queries(const std::vector<QueryPoint>& queries);
+    void highlight_line(size_t index, bool highlight = true);
+    void clear_highlights();
+
+private:
+    internal::LineContainerWidget* widget_ = nullptr;
+};
+
+// -----------------------------------------------------------------------------
+// Utility helpers
+// -----------------------------------------------------------------------------
+
+inline void reset_layout(LayoutStrategy strategy = LayoutStrategy::VerticalStack) {
+    set_layout_strategy(strategy);
+}
+
+} // namespace edulcni
+

--- a/include/edulcni/widgets/graph.hpp
+++ b/include/edulcni/widgets/graph.hpp
@@ -26,8 +26,10 @@ struct Vertex {
     double x, y;        // Position
     std::string label;  // Display label
     bool highlighted = false;
-    
-    Vertex(int id, double x, double y, std::string label) 
+    render::Color fill_color = render::Color(200, 200, 255);
+    render::Color stroke_color = render::Color::Black();
+
+    Vertex(int id, double x, double y, std::string label)
         : id(id), x(x), y(y), label(std::move(label)) {}
 };
 
@@ -105,12 +107,15 @@ public:
         
         // Render vertices
         for (const auto& vertex : vertices) {
-            render::Color bg_color = vertex.highlighted ? 
-                render::Color::Yellow() : render::Color(200, 200, 255);
-            
+            render::Color bg_color = vertex.highlighted ?
+                render::Color::Yellow() : vertex.fill_color;
+            render::Color border_color = vertex.highlighted ?
+                render::Color::Black() : vertex.stroke_color;
+            double stroke_width = vertex.highlighted ? 2.0 : 1.0;
+
             group->add(std::make_unique<render::Circle>(
                 vertex.x, vertex.y, 20,
-                bg_color, render::Color::Black(), 1.0
+                bg_color, border_color, stroke_width
             ));
             
             group->add(std::make_unique<render::Text>(
@@ -209,12 +214,15 @@ public:
         
         // Render vertices
         for (const auto& vertex : vertices) {
-            render::Color bg_color = vertex.highlighted ? 
-                render::Color::Yellow() : render::Color(200, 200, 255);
-            
+            render::Color bg_color = vertex.highlighted ?
+                render::Color::Yellow() : vertex.fill_color;
+            render::Color border_color = vertex.highlighted ?
+                render::Color::Black() : vertex.stroke_color;
+            double stroke_width = vertex.highlighted ? 2.0 : 1.0;
+
             group->add(std::make_unique<render::Circle>(
                 vertex.x, vertex.y, 20,
-                bg_color, render::Color::Black(), 1.0
+                bg_color, border_color, stroke_width
             ));
             
             group->add(std::make_unique<render::Text>(
@@ -320,14 +328,17 @@ public:
         
         // Render vertices
         for (const auto& vertex : vertices) {
-            render::Color bg_color = vertex.highlighted ? 
-                render::Color::Yellow() : render::Color(200, 200, 255);
-            
+            render::Color bg_color = vertex.highlighted ?
+                render::Color::Yellow() : vertex.fill_color;
+            render::Color border_color = vertex.highlighted ?
+                render::Color::Black() : vertex.stroke_color;
+            double stroke_width = vertex.highlighted ? 2.0 : 1.0;
+
             group->add(std::make_unique<render::Circle>(
                 vertex.x, vertex.y, 20,
-                bg_color, render::Color::Black(), 1.0
+                bg_color, border_color, stroke_width
             ));
-            
+
             group->add(std::make_unique<render::Text>(
                 vertex.x, vertex.y, vertex.label,
                 "14px Arial", render::Color::Black(), "center"
@@ -557,12 +568,15 @@ public:
         
         // Draw vertices
         for (const auto& vertex : vertices) {
-            render::Color bg_color = vertex.highlighted ? 
-                render::Color::Yellow() : render::Color::White();
-            
+            render::Color bg_color = vertex.highlighted ?
+                render::Color::Yellow() : vertex.fill_color;
+            render::Color border_color = vertex.highlighted ?
+                render::Color::Black() : vertex.stroke_color;
+            double stroke_width = vertex.highlighted ? 3.0 : 2.0;
+
             group->add(std::make_unique<render::Circle>(
                 vertex.x, vertex.y, 18,
-                bg_color, render::Color::Black(), 2.0
+                bg_color, border_color, stroke_width
             ));
             
             group->add(std::make_unique<render::Text>(
@@ -661,11 +675,46 @@ public:
             }
         }
     }
-    
+
+    void set_vertex_label(int id, const std::string& label) {
+        for (auto& vertex : vertices_) {
+            if (vertex.id == id) {
+                vertex.label = label;
+                break;
+            }
+        }
+    }
+
+    void set_vertex_labels(const std::vector<std::string>& labels) {
+        size_t limit = std::min(vertices_.size(), labels.size());
+        for (size_t i = 0; i < limit; ++i) {
+            vertices_[i].label = labels[i];
+        }
+    }
+
+    void set_vertex_color(int id, render::Color fill, render::Color stroke = render::Color::Black()) {
+        for (auto& vertex : vertices_) {
+            if (vertex.id == id) {
+                vertex.fill_color = fill;
+                vertex.stroke_color = stroke;
+                break;
+            }
+        }
+    }
+
+    void set_vertex_colors(const std::vector<render::Color>& fills,
+                           render::Color stroke = render::Color::Black()) {
+        size_t limit = std::min(vertices_.size(), fills.size());
+        for (size_t i = 0; i < limit; ++i) {
+            vertices_[i].fill_color = fills[i];
+            vertices_[i].stroke_color = stroke;
+        }
+    }
+
     void highlight_edge(int from, int to, bool highlight = true) {
         for (auto& edge : edges_) {
             // Check both directions for undirected graphs
-            if ((edge.from == from && edge.to == to) || 
+            if ((edge.from == from && edge.to == to) ||
                 (edge.from == to && edge.to == from)) {
                 edge.highlighted = highlight;
                 break;

--- a/scripts/generate_static_portfolio.py
+++ b/scripts/generate_static_portfolio.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""Build a consolidated portfolio directory for static examples.
+
+This script assumes all static examples were built already ("make examples-static").
+It will run each compiled example, collect the exported visualization assets, move
+those assets into a common portfolio directory, and generate an index page with
+convenient redirects.
+"""
+from __future__ import annotations
+
+import html
+import json
+import os
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+STATIC_EXAMPLES_DIR = REPO_ROOT / "examples" / "static"
+BUILD_OUTPUT_DIR = REPO_ROOT / "out"
+PORTFOLIO_DIR = REPO_ROOT / "portfolio"
+
+INITIALIZE_PATTERN = re.compile(r"initialize\s*\(\s*\"([^\"]+)\"")
+
+
+@dataclass
+class ExampleMetadata:
+    name: str
+    output_path: Path
+    display_name: str
+    summary: str | None
+
+
+def extract_output_path(example_source: Path) -> tuple[Path, str | None]:
+    """Return the output directory and optional summary comment for an example."""
+    text = example_source.read_text(encoding="utf-8", errors="ignore")
+    match = INITIALIZE_PATTERN.search(text)
+    if not match:
+        raise ValueError(f"Could not find edulcni::initialize path in {example_source}")
+
+    raw_path = match.group(1)
+    comment_summary = None
+
+    # Attempt to capture a leading comment block as the summary.
+    comment_match = re.search(r"/\*\*(.*?)\*/", text, re.DOTALL)
+    if comment_match:
+        summary = comment_match.group(1).strip()
+        # Use the first non-empty line as the summary sentence.
+        for line in summary.splitlines():
+            stripped = line.strip(" *")
+            if stripped:
+                comment_summary = stripped
+                break
+
+    return Path(raw_path), comment_summary
+
+
+def derive_display_name(example_name: str) -> str:
+    words = example_name.replace("_", " ").split()
+    return " ".join(w.capitalize() for w in words)
+
+
+def move_output(source_path: Path, destination_dir: Path) -> None:
+    if destination_dir.exists():
+        shutil.rmtree(destination_dir)
+    destination_dir.parent.mkdir(parents=True, exist_ok=True)
+    shutil.move(str(source_path), str(destination_dir))
+
+
+def make_redirect_page(example: ExampleMetadata) -> None:
+    redirect_target = f"{example.name}/index.html"
+    redirect_html = f"""<!DOCTYPE html>
+<html lang=\"en\">
+  <head>
+    <meta charset=\"utf-8\">
+    <title>{html.escape(example.display_name)}</title>
+    <meta http-equiv=\"refresh\" content=\"0; url={redirect_target}\">
+    <link rel=\"canonical\" href=\"{redirect_target}\">
+    <style>
+      body {{
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        padding: 3rem 1.5rem;
+        background: #111827;
+        color: #f9fafb;
+        text-align: center;
+      }}
+      a {{ color: #38bdf8; }}
+    </style>
+  </head>
+  <body>
+    <h1>Redirecting to {html.escape(example.display_name)}</h1>
+    <p>If you are not redirected automatically, <a href=\"{redirect_target}\">click here to open the visualization.</a></p>
+  </body>
+</html>
+"""
+    (PORTFOLIO_DIR / f"{example.name}.html").write_text(redirect_html, encoding="utf-8")
+
+
+def make_index_page(examples: List[ExampleMetadata]) -> None:
+    list_items = []
+    for example in examples:
+        summary_text = html.escape(example.summary) if example.summary else ""
+        description = f"<p class=\"summary\">{summary_text}</p>" if summary_text else ""
+        list_items.append(
+            f"""<li><a href=\"{example.name}.html\">{html.escape(example.display_name)}</a>{description}</li>"""
+        )
+
+    index_html = f"""<!DOCTYPE html>
+<html lang=\"en\">
+  <head>
+    <meta charset=\"utf-8\">
+    <title>Edulcni Static Example Portfolio</title>
+    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">
+    <style>
+      :root {{
+        color-scheme: dark;
+      }}
+      body {{
+        margin: 0;
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        background: #0b1120;
+        color: #e2e8f0;
+        min-height: 100vh;
+        display: flex;
+        justify-content: center;
+      }}
+      main {{
+        width: min(900px, 100%);
+        padding: clamp(1.5rem, 5vw, 4rem);
+      }}
+      h1 {{
+        font-size: clamp(2rem, 5vw, 3.25rem);
+        margin-bottom: 1.25rem;
+        text-align: center;
+      }}
+      p.lead {{
+        text-align: center;
+        color: #94a3b8;
+        margin-bottom: 2rem;
+      }}
+      ul.examples {{
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        display: grid;
+        gap: 1.25rem;
+      }}
+      ul.examples li {{
+        background: rgba(30, 41, 59, 0.75);
+        border: 1px solid rgba(148, 163, 184, 0.2);
+        border-radius: 1rem;
+        padding: 1.25rem;
+        transition: transform 0.2s ease, border-color 0.2s ease;
+      }}
+      ul.examples li:hover {{
+        transform: translateY(-4px);
+        border-color: rgba(56, 189, 248, 0.6);
+      }}
+      ul.examples a {{
+        color: #38bdf8;
+        font-weight: 600;
+        font-size: 1.1rem;
+        text-decoration: none;
+      }}
+      ul.examples p.summary {{
+        margin: 0.65rem 0 0;
+        color: #cbd5f5;
+        line-height: 1.4;
+      }}
+      footer {{
+        margin-top: 2.5rem;
+        text-align: center;
+        color: #64748b;
+        font-size: 0.9rem;
+      }}
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Edulcni Static Examples</h1>
+      <p class=\"lead\">Explore the growing gallery of algorithm and data-structure visualizations generated from the static examples.</p>
+      <ul class=\"examples\">
+        {''.join(list_items)}
+      </ul>
+      <footer>
+        Built automatically from the <code>examples/static</code> suite.
+      </footer>
+    </main>
+  </body>
+</html>
+"""
+    (PORTFOLIO_DIR / "index.html").write_text(index_html, encoding="utf-8")
+
+
+def ensure_portfolio_dir() -> None:
+    if PORTFOLIO_DIR.exists():
+        shutil.rmtree(PORTFOLIO_DIR)
+    PORTFOLIO_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def main() -> None:
+    ensure_portfolio_dir()
+
+    examples: List[ExampleMetadata] = []
+
+    for example_source in sorted(STATIC_EXAMPLES_DIR.glob("*.cpp")):
+        example_name = example_source.stem
+        binary_path = BUILD_OUTPUT_DIR / example_name
+        if not binary_path.exists():
+            raise FileNotFoundError(
+                f"Compiled binary {binary_path} missing. Run 'make examples-static' first."
+            )
+
+        output_spec, summary = extract_output_path(example_source)
+        temp_binary = binary_path.with_name(f"{binary_path.name}_runner")
+        if temp_binary.exists():
+            temp_binary.unlink()
+        binary_path.rename(temp_binary)
+
+        try:
+            subprocess.run([str(temp_binary)], cwd=REPO_ROOT, check=True)
+
+            output_path = output_spec
+            if not output_path.is_absolute():
+                output_path = (REPO_ROOT / output_path).resolve()
+
+            if not output_path.exists():
+                raise FileNotFoundError(
+                    f"Expected visualization output at {output_path} after running {temp_binary}"
+                )
+
+            destination_dir = PORTFOLIO_DIR / example_name
+            move_output(output_path, destination_dir)
+
+            metadata = ExampleMetadata(
+                name=example_name,
+                output_path=destination_dir,
+                display_name=derive_display_name(example_name),
+                summary=summary,
+            )
+            make_redirect_page(metadata)
+            examples.append(metadata)
+        finally:
+            try:
+                if temp_binary.exists():
+                    temp_binary.rename(binary_path)
+            except OSError:
+                # Best-effort cleanup; leave the renamed binary in place if rename fails.
+                pass
+
+    make_index_page(examples)
+
+    # Persist metadata to make debugging easier.
+    metadata_file = PORTFOLIO_DIR / "portfolio.json"
+    metadata_payload = [
+        {
+            "name": example.name,
+            "display_name": example.display_name,
+            "output_path": os.path.relpath(example.output_path, PORTFOLIO_DIR),
+            "summary": example.summary,
+        }
+        for example in examples
+    ]
+    metadata_file.write_text(
+        json.dumps(metadata_payload, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/widgets/data_structures.cpp
+++ b/src/widgets/data_structures.cpp
@@ -1,0 +1,558 @@
+#include "edulcni/widgets/data_structures.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <sstream>
+
+namespace edulcni {
+
+// -----------------------------------------------------------------------------
+// Segment tree view implementation
+// -----------------------------------------------------------------------------
+
+SegmentTreeView::SegmentTreeView(const std::string& id, size_t leaf_count)
+    : id_(id), leaf_count_(leaf_count) {
+    widget_ = internal::State::instance()
+        .get_or_create_widget<internal::GraphWidget>(id_);
+
+    base_size_ = 1;
+    while (base_size_ < std::max<size_t>(1, leaf_count_)) {
+        base_size_ <<= 1;
+    }
+
+    const size_t node_count = base_size_ * 2 - 1;
+    values_.assign(node_count, std::string{});
+    ranges_.assign(node_count, {0, 0});
+    active_.assign(node_count, false);
+
+    build_structure();
+}
+
+void SegmentTreeView::build_structure() {
+    const size_t node_count = values_.size();
+    if (node_count == 0 || !widget_) {
+        return;
+    }
+
+    std::vector<std::vector<int>> adj(node_count);
+    for (size_t i = 0; i < node_count; ++i) {
+        size_t left = 2 * i + 1;
+        size_t right = 2 * i + 2;
+        if (left < node_count) {
+            adj[i].push_back(static_cast<int>(left));
+            adj[left].push_back(static_cast<int>(i));
+        }
+        if (right < node_count) {
+            adj[i].push_back(static_cast<int>(right));
+            adj[right].push_back(static_cast<int>(i));
+        }
+    }
+
+    widget_->set_tree(adj, 0);
+    compute_ranges(0, 0, base_size_ - 1);
+    update_labels();
+}
+
+void SegmentTreeView::compute_ranges(size_t index, size_t left, size_t right) {
+    if (index >= values_.size()) {
+        return;
+    }
+
+    if (index >= base_size_ - 1) {
+        if (leaf_count_ == 0 || left >= leaf_count_) {
+            ranges_[index] = {left, left};
+            active_[index] = false;
+        } else {
+            size_t clamped_right = std::min(right, leaf_count_ - 1);
+            ranges_[index] = {left, clamped_right};
+            active_[index] = true;
+        }
+        return;
+    }
+
+    size_t mid = (left + right) / 2;
+    compute_ranges(2 * index + 1, left, mid);
+    compute_ranges(2 * index + 2, mid + 1, right);
+
+    const bool left_active = active_[2 * index + 1];
+    const bool right_active = active_[2 * index + 2];
+
+    if (left_active && right_active) {
+        ranges_[index] = {
+            ranges_[2 * index + 1].first,
+            ranges_[2 * index + 2].second
+        };
+        active_[index] = true;
+    } else if (left_active) {
+        ranges_[index] = ranges_[2 * index + 1];
+        active_[index] = true;
+    } else if (right_active) {
+        ranges_[index] = ranges_[2 * index + 2];
+        active_[index] = true;
+    } else {
+        ranges_[index] = {left, left};
+        active_[index] = false;
+    }
+}
+
+void SegmentTreeView::update_labels() {
+    if (!widget_) {
+        return;
+    }
+
+    std::vector<std::string> labels(values_.size(), "∅");
+    for (size_t i = 0; i < values_.size(); ++i) {
+        if (!active_[i] || leaf_count_ == 0) {
+            continue;
+        }
+
+        const auto& range = ranges_[i];
+        std::string label = "[" + std::to_string(range.first) + "," + std::to_string(range.second) + "]";
+        if (!values_[i].empty()) {
+            label += ": " + values_[i];
+        }
+        labels[i] = std::move(label);
+    }
+
+    widget_->set_vertex_labels(labels);
+}
+
+void SegmentTreeView::set_value(size_t node_index, const std::string& value) {
+    if (node_index >= values_.size()) {
+        return;
+    }
+    values_[node_index] = value;
+    update_labels();
+}
+
+void SegmentTreeView::set_leaf_value(size_t leaf_index, const std::string& value) {
+    size_t offset = leaf_offset();
+    if (leaf_index >= leaf_count_ || offset + leaf_index >= values_.size()) {
+        return;
+    }
+    set_value(offset + leaf_index, value);
+}
+
+void SegmentTreeView::clear_values() {
+    std::fill(values_.begin(), values_.end(), std::string{});
+    update_labels();
+}
+
+void SegmentTreeView::highlight_node(size_t node_index, bool highlight) {
+    if (!widget_ || node_index >= values_.size()) {
+        return;
+    }
+    widget_->highlight_vertex(static_cast<int>(node_index), highlight);
+}
+
+void SegmentTreeView::highlight_range(size_t left, size_t right, bool highlight) {
+    if (!widget_ || values_.empty() || left > right) {
+        return;
+    }
+
+    for (size_t i = 0; i < values_.size(); ++i) {
+        if (!active_[i]) {
+            continue;
+        }
+        const auto& range = ranges_[i];
+        if (range.first >= left && range.second <= right) {
+            widget_->highlight_vertex(static_cast<int>(i), highlight);
+        }
+    }
+}
+
+void SegmentTreeView::clear_highlights() {
+    if (widget_) {
+        widget_->clear_highlights();
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Treap view implementation
+// -----------------------------------------------------------------------------
+
+TreapView::TreapView(const std::string& id) : id_(id) {
+    widget_ = internal::State::instance()
+        .get_or_create_widget<internal::GraphWidget>(id_);
+}
+
+void TreapView::set_tree(const std::vector<Node>& nodes, int root_id) {
+    if (!widget_) {
+        return;
+    }
+
+    id_to_index_.clear();
+    if (nodes.empty()) {
+        widget_->set_graph({});
+        return;
+    }
+
+    widget_->clear_highlights();
+
+    for (size_t i = 0; i < nodes.size(); ++i) {
+        id_to_index_[nodes[i].id] = i;
+    }
+
+    std::vector<std::vector<int>> adj(nodes.size());
+    for (size_t i = 0; i < nodes.size(); ++i) {
+        if (nodes[i].left != -1) {
+            auto it = id_to_index_.find(nodes[i].left);
+            if (it != id_to_index_.end()) {
+                adj[i].push_back(static_cast<int>(it->second));
+                adj[it->second].push_back(static_cast<int>(i));
+            }
+        }
+        if (nodes[i].right != -1) {
+            auto it = id_to_index_.find(nodes[i].right);
+            if (it != id_to_index_.end()) {
+                adj[i].push_back(static_cast<int>(it->second));
+                adj[it->second].push_back(static_cast<int>(i));
+            }
+        }
+    }
+
+    size_t root_index = 0;
+    if (auto it = id_to_index_.find(root_id); it != id_to_index_.end()) {
+        root_index = it->second;
+    }
+
+    widget_->set_tree(adj, static_cast<int>(root_index));
+
+    std::vector<std::string> labels(nodes.size());
+    for (size_t i = 0; i < nodes.size(); ++i) {
+        std::string label = nodes[i].key;
+        if (!nodes[i].priority.empty()) {
+            label += " | " + nodes[i].priority;
+        }
+        labels[i] = std::move(label);
+        widget_->set_vertex_color(static_cast<int>(i), nodes[i].color);
+        if (nodes[i].highlighted) {
+            widget_->highlight_vertex(static_cast<int>(i), true);
+        }
+    }
+
+    widget_->set_vertex_labels(labels);
+}
+
+void TreapView::highlight(int node_id, bool highlight) {
+    if (!widget_) {
+        return;
+    }
+    auto it = id_to_index_.find(node_id);
+    if (it != id_to_index_.end()) {
+        widget_->highlight_vertex(static_cast<int>(it->second), highlight);
+    }
+}
+
+void TreapView::clear_highlights() {
+    if (widget_) {
+        widget_->clear_highlights();
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Sqrt decomposition view implementation
+// -----------------------------------------------------------------------------
+
+SqrtDecompositionView::SqrtDecompositionView(const std::string& id)
+    : array_id_(id + "_array"), blocks_id_(id + "_blocks") {}
+
+void SqrtDecompositionView::highlight_element(size_t index) {
+    highlight_single(array_id_, static_cast<int>(index));
+}
+
+void SqrtDecompositionView::highlight_block(size_t index) {
+    highlight_single(blocks_id_, static_cast<int>(index));
+}
+
+void SqrtDecompositionView::clear_highlights() {
+    ::edulcni::clear_highlights(array_id_);
+    ::edulcni::clear_highlights(blocks_id_);
+}
+
+// -----------------------------------------------------------------------------
+// Line container widget implementation
+// -----------------------------------------------------------------------------
+
+namespace internal {
+
+namespace {
+    std::string default_line_label(double slope, double intercept) {
+        std::ostringstream ss;
+        ss.setf(std::ios::fixed);
+        ss.precision(2);
+        ss << "y = " << slope << "x";
+        if (intercept > 1e-9) {
+            ss << " + " << intercept;
+        } else if (intercept < -1e-9) {
+            ss << " - " << std::abs(intercept);
+        }
+        return ss.str();
+    }
+}
+
+class LineContainerWidget : public Widget {
+public:
+    struct LineState {
+        double slope = 0.0;
+        double intercept = 0.0;
+        std::string label;
+        render::Color color = render::Color(52, 152, 219);
+        bool highlighted = false;
+    };
+
+    struct QueryState {
+        double x = 0.0;
+        size_t line_index = 0;
+        render::Color color = render::Color::Red();
+    };
+
+    LineContainerWidget(std::string id) : Widget(std::move(id)) {
+        calculate_dimensions();
+    }
+
+    void set_domain(double min_x, double max_x) {
+        if (min_x == max_x) {
+            max_x += 1.0;
+        }
+        min_x_ = std::min(min_x, max_x);
+        max_x_ = std::max(min_x, max_x);
+        update_range();
+    }
+
+    void set_lines(std::vector<LineState> lines) {
+        lines_ = std::move(lines);
+        update_range();
+    }
+
+    void set_queries(std::vector<QueryState> queries) {
+        queries_ = std::move(queries);
+        update_range();
+    }
+
+    void highlight_line(size_t index, bool highlight) {
+        if (index < lines_.size()) {
+            lines_[index].highlighted = highlight;
+        }
+    }
+
+    void clear_highlights() {
+        for (auto& line : lines_) {
+            line.highlighted = false;
+        }
+    }
+
+    void calculate_dimensions() override {
+        width_ = 620;
+        height_ = 380;
+    }
+
+    std::unique_ptr<render::Element> render() const override {
+        auto group = std::make_unique<render::Group>();
+
+        group->add(std::make_unique<render::Rectangle>(
+            0, 0, width_, height_, render::Color(248, 249, 250), render::Color(224, 224, 224), 1.0
+        ));
+
+        const double padding = 50.0;
+        const double plot_width = std::max(10.0, width_ - 2 * padding);
+        const double plot_height = std::max(10.0, height_ - 2 * padding);
+
+        auto map_x = [&](double x) {
+            if (std::abs(max_x_ - min_x_) < 1e-9) {
+                return padding + plot_width / 2.0;
+            }
+            return padding + (x - min_x_) / (max_x_ - min_x_) * plot_width;
+        };
+
+        auto map_y = [&](double y) {
+            if (std::abs(max_y_ - min_y_) < 1e-9) {
+                return padding + plot_height / 2.0;
+            }
+            double normalized = (y - min_y_) / (max_y_ - min_y_);
+            return padding + plot_height - normalized * plot_height;
+        };
+
+        // Plot background
+        group->add(std::make_unique<render::Rectangle>(
+            padding, padding, plot_width, plot_height,
+            render::Color::White(), render::Color(210, 210, 210), 1.0
+        ));
+
+        // Axes
+        if (min_x_ <= 0.0 && max_x_ >= 0.0) {
+            double axis_x = map_x(0.0);
+            group->add(std::make_unique<render::Line>(
+                axis_x, padding, axis_x, padding + plot_height,
+                render::Color(200, 200, 200), 1.0
+            ));
+        }
+        if (min_y_ <= 0.0 && max_y_ >= 0.0) {
+            double axis_y = map_y(0.0);
+            group->add(std::make_unique<render::Line>(
+                padding, axis_y, padding + plot_width, axis_y,
+                render::Color(200, 200, 200), 1.0
+            ));
+        }
+
+        for (size_t idx = 0; idx < lines_.size(); ++idx) {
+            const auto& line = lines_[idx];
+            double y1 = line.slope * min_x_ + line.intercept;
+            double y2 = line.slope * max_x_ + line.intercept;
+
+            double sx1 = map_x(min_x_);
+            double sy1 = map_y(y1);
+            double sx2 = map_x(max_x_);
+            double sy2 = map_y(y2);
+
+            render::Color color = line.highlighted ? render::Color::Red() : line.color;
+            double stroke_width = line.highlighted ? 3.0 : 1.5;
+
+            group->add(std::make_unique<render::Line>(
+                sx1, sy1, sx2, sy2, color, stroke_width
+            ));
+
+            std::string label = line.label.empty() ? default_line_label(line.slope, line.intercept) : line.label;
+            group->add(std::make_unique<render::Text>(
+                sx2 - 6, sy2 - 12, label, "12px Arial", color, "right"
+            ));
+        }
+
+        for (const auto& query : queries_) {
+            if (query.line_index >= lines_.size()) {
+                continue;
+            }
+            const auto& line = lines_[query.line_index];
+            double y = line.slope * query.x + line.intercept;
+
+            double sx = map_x(query.x);
+            double sy = map_y(y);
+
+            group->add(std::make_unique<render::Circle>(
+                sx, sy, 5.0, query.color, render::Color::Black(), 1.0
+            ));
+
+            std::ostringstream label;
+            label.setf(std::ios::fixed);
+            label.precision(2);
+            label << "x=" << query.x << " → " << y;
+            group->add(std::make_unique<render::Text>(
+                sx + 8, sy - 8, label.str(), "11px Arial", query.color, "left"
+            ));
+        }
+
+        return group;
+    }
+
+private:
+    double min_x_ = -10.0;
+    double max_x_ = 10.0;
+    double min_y_ = -10.0;
+    double max_y_ = 10.0;
+    std::vector<LineState> lines_;
+    std::vector<QueryState> queries_;
+
+    void update_range() {
+        double min_val = std::numeric_limits<double>::max();
+        double max_val = std::numeric_limits<double>::lowest();
+
+        auto consider = [&](double y) {
+            min_val = std::min(min_val, y);
+            max_val = std::max(max_val, y);
+        };
+
+        for (const auto& line : lines_) {
+            consider(line.slope * min_x_ + line.intercept);
+            consider(line.slope * max_x_ + line.intercept);
+        }
+        for (const auto& query : queries_) {
+            if (query.line_index < lines_.size()) {
+                const auto& line = lines_[query.line_index];
+                consider(line.slope * query.x + line.intercept);
+            }
+        }
+
+        if (min_val == std::numeric_limits<double>::max()) {
+            min_val = -1.0;
+            max_val = 1.0;
+        }
+
+        double padding = (max_val - min_val) * 0.1;
+        if (padding < 1.0) {
+            padding = 1.0;
+        }
+
+        min_y_ = min_val - padding;
+        max_y_ = max_val + padding;
+        if (std::abs(max_y_ - min_y_) < 1e-9) {
+            max_y_ = min_y_ + 1.0;
+        }
+    }
+};
+
+} // namespace internal
+
+// -----------------------------------------------------------------------------
+// Line container view implementation
+// -----------------------------------------------------------------------------
+
+LineContainerView::LineContainerView(const std::string& id) {
+    widget_ = internal::State::instance()
+        .get_or_create_widget<internal::LineContainerWidget>(id);
+}
+
+void LineContainerView::set_domain(double min_x, double max_x) {
+    if (widget_) {
+        widget_->set_domain(min_x, max_x);
+    }
+}
+
+void LineContainerView::set_lines(const std::vector<LineDefinition>& lines) {
+    if (!widget_) {
+        return;
+    }
+    std::vector<internal::LineContainerWidget::LineState> converted;
+    converted.reserve(lines.size());
+    for (const auto& line : lines) {
+        internal::LineContainerWidget::LineState state;
+        state.slope = line.slope;
+        state.intercept = line.intercept;
+        state.label = line.label;
+        state.color = line.color;
+        state.highlighted = line.highlighted;
+        converted.push_back(std::move(state));
+    }
+    widget_->set_lines(std::move(converted));
+}
+
+void LineContainerView::set_queries(const std::vector<QueryPoint>& queries) {
+    if (!widget_) {
+        return;
+    }
+    std::vector<internal::LineContainerWidget::QueryState> converted;
+    converted.reserve(queries.size());
+    for (const auto& query : queries) {
+        internal::LineContainerWidget::QueryState state;
+        state.x = query.x;
+        state.line_index = query.line_index;
+        state.color = query.color;
+        converted.push_back(std::move(state));
+    }
+    widget_->set_queries(std::move(converted));
+}
+
+void LineContainerView::highlight_line(size_t index, bool highlight) {
+    if (widget_) {
+        widget_->highlight_line(index, highlight);
+    }
+}
+
+void LineContainerView::clear_highlights() {
+    if (widget_) {
+        widget_->clear_highlights();
+    }
+}
+
+} // namespace edulcni
+

--- a/static/templates/static_viewer_template.html
+++ b/static/templates/static_viewer_template.html
@@ -277,6 +277,7 @@
                 this.playSpeed = 1.0;
                 this.canvas = document.getElementById('frameCanvas');
                 this.ctx = this.canvas.getContext('2d');
+                this.canvasMeta = null;
                 
                 // Panning and zooming state
                 this.isPanning = false;
@@ -513,21 +514,36 @@
                     if (typeof window.frameData === 'undefined') {
                         throw new Error('Frame data not found. Make sure the data file defines window.frameData');
                     }
-                    
-                    if (!Array.isArray(window.frameData)) {
-                        throw new Error('Frame data must be an array');
+
+                    const defaultCanvas = { width: 800, height: 600, offsetX: 0, offsetY: 0 };
+
+                    if (Array.isArray(window.frameData)) {
+                        this.frames = window.frameData;
+                        this.canvasMeta = defaultCanvas;
+                    } else if (window.frameData && Array.isArray(window.frameData.frames)) {
+                        this.frames = window.frameData.frames;
+                        const canvas = window.frameData.canvas || {};
+                        this.canvasMeta = {
+                            width: canvas.width || defaultCanvas.width,
+                            height: canvas.height || defaultCanvas.height,
+                            offsetX: canvas.offsetX || defaultCanvas.offsetX,
+                            offsetY: canvas.offsetY || defaultCanvas.offsetY
+                        };
+                    } else {
+                        throw new Error('Frame data must be an array or an object with a frames array');
                     }
-                    
-                    this.frames = window.frameData;
+
+                    this.canvas.width = this.canvasMeta.width;
+                    this.canvas.height = this.canvasMeta.height;
                     this.initializeViewer();
-                    
+
                 } catch (error) {
                     this.showError(`Error loading frame data: ${error.message}`);
                 }
             }
 
             initializeViewer() {
-                if (this.frames.length === 0) {
+                if (!Array.isArray(this.frames) || this.frames.length === 0) {
                     this.showError('No frames found in data file');
                     return;
                 }
@@ -569,13 +585,20 @@
                 
                 // Set up canvas context
                 this.ctx.save();
-                
+                if (this.canvasMeta) {
+                    this.ctx.translate(-this.canvasMeta.offsetX, -this.canvasMeta.offsetY);
+                }
+
                 try {
                     const frameInstructions = this.frames[frameIndex];
-                    
+                    if (typeof frameInstructions !== 'function') {
+                        console.warn('Frame is not a function:', frameInstructions);
+                        return;
+                    }
+
                     // Always treat as function and call with ctx and canvas
                     frameInstructions(this.ctx, this.canvas);
-                    
+
                 } catch (error) {
                     console.error(`Error drawing frame ${frameIndex}:`, error);
                     this.ctx.fillStyle = '#ff0000';


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds every static example and publishes the generated gallery to GitHub Pages
- provide a portfolio generation script that runs each compiled example, moves the exports into a single site, and writes redirects plus metadata
- document the publishing flow in the README and ignore local build artifacts

## Testing
- make examples-static
- python3 scripts/generate_static_portfolio.py


------
https://chatgpt.com/codex/tasks/task_e_68e521463010832eab281d963f6712b3